### PR TITLE
chore(docs): add console playground

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,14 +15,14 @@
     "singleQuote": true
   },
   "dependencies": {
+    "@nordic-ui/validathor": "*",
     "clsx": "^2.1.0",
     "fathom-client": "^3.5.0",
     "next": "^14.2.4",
     "nextra": "^2.13.4",
     "nextra-theme-docs": "latest",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "validathor": "*"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "18.11.10",

--- a/apps/docs/pages/_app.tsx
+++ b/apps/docs/pages/_app.tsx
@@ -1,10 +1,50 @@
-import type { AppProps } from 'next/app';
+import type { AppProps } from 'next/app'
+import { useEffect } from 'react'
 
-import { useAnalytics } from '../lib/analytics';
+import { useAnalytics } from '../lib/analytics'
 
 import '../styles.css'
- 
+
 export default function MyApp({ Component, pageProps }: AppProps) {
-  useAnalytics();
+  useAnalytics()
+
+  useEffect(() => {
+    const HEADER_STYLE = 'color: #FFAB70; font-size: 16px; font-family: sans-serif;'
+    const MESSAGE_STYLE = 'font-family: sans-serif;'
+    const CODE_STYLE = 'color: #79B8FF; font-family: monospace;'
+
+    async function init() {
+      try {
+        const validathor = await import('@nordic-ui/validathor')
+        // @ts-expect-error - Add the library to the window object
+        window.v = validathor
+        // @ts-expect-error - Add the library to the window object
+        window.validathor = validathor
+        // Write a console.log message to inform the user that the library is available with an example
+        console.log(
+          `%c\nYou can now use the library in the browser console.
+          \nTry   %cvalidathor.object({ name: validathor.string() }).parse({ name: 'John' })%c
+          \nOr   %ctry { validathor.number().parse(true) } catch (err) { console.log('Validation failed:', err.message) }%c`,
+          MESSAGE_STYLE,
+          CODE_STYLE,
+          MESSAGE_STYLE,
+          CODE_STYLE,
+          MESSAGE_STYLE,
+        )
+      } catch (err) {
+        console.error('Something went wrong:', err)
+      }
+    }
+    console.log(
+      `%cValidaThor ⚡️%c\nRun %cinit()%c to make ValidaThor available in the browser console.`,
+      HEADER_STYLE,
+      MESSAGE_STYLE,
+      CODE_STYLE,
+      MESSAGE_STYLE,
+    )
+    // @ts-expect-error - Add the init function to the window
+    window.init = init
+  }, [])
+
   return <Component {...pageProps} />
 }

--- a/apps/docs/theme.config.tsx
+++ b/apps/docs/theme.config.tsx
@@ -8,7 +8,7 @@ const WordMark = () => (
   </span>
 )
 
-const config: DocsThemeConfig = {
+const config = {
   logo: <WordMark />,
   project: {
     link: 'https://github.com/kosai106/validathor',
@@ -74,6 +74,6 @@ const config: DocsThemeConfig = {
   main({ children }) {
     return <>{children}</>
   },
-}
+} satisfies DocsThemeConfig
 
 export default config


### PR DESCRIPTION
Inspired by [date-fns](https://github.com/date-fns/date-fns), it's now possible to initialize ValidaThor in the browser console to play around with.

Simply visit the docs, open the browser console and run `init()`, and then `validathor` is available as a command.